### PR TITLE
add TLS support and some refactoring

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,21 @@ func main() {
 }
 ```
 
+###TLS SUPPORT
+In order to use TLS connection to manager interface you could `Dial` with additional parameters
+```go
+//without TLS
+ami, err := gami.Dial("127.0.0.1:5038")
 
+//if certificate is trusted
+ami, err := gami.Dial("127.0.0.1:5039", gami.UseTLS)
+
+//if self signed certificate
+ami, err := gami.Dial("127.0.0.1:5039", gami.UseTLS, gami.UnsecureTLS)
+```
+**WARNING:**
+*Only Asterisk >=1.6 supports TLS connection to AMI and
+it needs additional configuration(follow the [Asterisk AMI configuration](http://www.asteriskdocs.org/en/3rd_Edition/asterisk-book-html-chunk/AMI-configuration.html) documentation)*
 
 CURRENT EVENT TYPES
 ====
@@ -98,5 +112,3 @@ EVENT ID          | TYPE TEST
 *RTPReceiverStats* | YES
 *RTPSenderStats* | YES
 *Bridge* | YES
-
-

--- a/event/agent_connect_test.go
+++ b/event/agent_connect_test.go
@@ -1,8 +1,9 @@
 package event
 
 import (
-	"github.com/bit4bit/gami"
 	"testing"
+
+	"github.com/bit4bit/gami"
 )
 
 func TestAgentConnect(t *testing.T) {

--- a/event/agent_login_test.go
+++ b/event/agent_login_test.go
@@ -1,8 +1,9 @@
 package event
 
 import (
-	"github.com/bit4bit/gami"
 	"testing"
+
+	"github.com/bit4bit/gami"
 )
 
 func TestAgentLogin(t *testing.T) {

--- a/event/agent_logoff_test.go
+++ b/event/agent_logoff_test.go
@@ -1,8 +1,9 @@
 package event
 
 import (
-	"github.com/bit4bit/gami"
 	"testing"
+
+	"github.com/bit4bit/gami"
 )
 
 func TestAgentLogoff(t *testing.T) {

--- a/event/agents_test.go
+++ b/event/agents_test.go
@@ -1,8 +1,9 @@
 package event
 
 import (
-	"github.com/bit4bit/gami"
 	"testing"
+
+	"github.com/bit4bit/gami"
 )
 
 func TestAgentsEvent(t *testing.T) {

--- a/event/bridge_test.go
+++ b/event/bridge_test.go
@@ -2,8 +2,9 @@
 package event
 
 import (
-	"github.com/bit4bit/gami"
 	"testing"
+
+	"github.com/bit4bit/gami"
 )
 
 func TestBridge(t *testing.T) {

--- a/event/dial_test.go
+++ b/event/dial_test.go
@@ -1,8 +1,9 @@
 package event
 
 import (
-	"github.com/bit4bit/gami"
 	"testing"
+
+	"github.com/bit4bit/gami"
 )
 
 func TestDialEvent(t *testing.T) {

--- a/event/event.go
+++ b/event/event.go
@@ -4,9 +4,10 @@ package event
 
 import (
 	"fmt"
-	"github.com/bit4bit/gami"
 	"reflect"
 	"strconv"
+
+	"github.com/bit4bit/gami"
 )
 
 // eventTrap used internal for trap events and cast

--- a/event/extension_status_test.go
+++ b/event/extension_status_test.go
@@ -1,8 +1,9 @@
 package event
 
 import (
-	"github.com/bit4bit/gami"
 	"testing"
+
+	"github.com/bit4bit/gami"
 )
 
 func TestExtensionStatus(t *testing.T) {

--- a/event/hangup_test.go
+++ b/event/hangup_test.go
@@ -1,8 +1,9 @@
 package event
 
 import (
-	"github.com/bit4bit/gami"
 	"testing"
+
+	"github.com/bit4bit/gami"
 )
 
 func TestHangupEvent(t *testing.T) {

--- a/event/newchannel_test.go
+++ b/event/newchannel_test.go
@@ -1,8 +1,9 @@
 package event
 
 import (
-	"github.com/bit4bit/gami"
 	"testing"
+
+	"github.com/bit4bit/gami"
 )
 
 func TestNewchannel(t *testing.T) {

--- a/event/newexten_test.go
+++ b/event/newexten_test.go
@@ -1,8 +1,9 @@
 package event
 
 import (
-	"github.com/bit4bit/gami"
 	"testing"
+
+	"github.com/bit4bit/gami"
 )
 
 func TestNewexten(t *testing.T) {

--- a/event/newstate_test.go
+++ b/event/newstate_test.go
@@ -1,8 +1,9 @@
 package event
 
 import (
-	"github.com/bit4bit/gami"
 	"testing"
+
+	"github.com/bit4bit/gami"
 )
 
 func TestNewstateEvent(t *testing.T) {

--- a/event/peer_status_test.go
+++ b/event/peer_status_test.go
@@ -1,8 +1,9 @@
 package event
 
 import (
-	"github.com/bit4bit/gami"
 	"testing"
+
+	"github.com/bit4bit/gami"
 )
 
 func TestPeerStatus(t *testing.T) {

--- a/event/rtp_receiver_stats_test.go
+++ b/event/rtp_receiver_stats_test.go
@@ -1,8 +1,9 @@
 package event
 
 import (
-	"github.com/bit4bit/gami"
 	"testing"
+
+	"github.com/bit4bit/gami"
 )
 
 func TestRTPReceiverStats(t *testing.T) {

--- a/event/rtp_sender_stats_test.go
+++ b/event/rtp_sender_stats_test.go
@@ -1,8 +1,9 @@
 package event
 
 import (
-	"github.com/bit4bit/gami"
 	"testing"
+
+	"github.com/bit4bit/gami"
 )
 
 func TestRTPSenderStats(t *testing.T) {

--- a/event/var_set_test.go
+++ b/event/var_set_test.go
@@ -1,8 +1,9 @@
 package event
 
 import (
-	"github.com/bit4bit/gami"
 	"testing"
+
+	"github.com/bit4bit/gami"
 )
 
 func TestVarSetEvent(t *testing.T) {


### PR DESCRIPTION
as of asterisk >= 1.6, manager interface supports TLS.

With this PR it is possible to use it.

``` go
//without TLS
ami, err := gami.Dial("127.0.0.1:5038")

//if certificate is trusted
ami, err := gami.Dial("127.0.0.1:5039", gami.UseTLS)

//if self signed certificate
ami, err := gami.Dial("127.0.0.1:5039", gami.UseTLS, gami.UnsecureTLS)
```
